### PR TITLE
Update for Xcode 14.1+

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,10 +1,10 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '11.0'
 
 target 'Quickstart' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-pod 'SendBirdCalls'
+  pod 'SendBirdCalls'
 
 end

--- a/Quickstart/Room/RoomViewController.swift
+++ b/Quickstart/Room/RoomViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SendBirdCalls
 import AVKit
 
-protocol RoomDataSource: class {
+protocol RoomDataSource: AnyObject {
     var room: Room! { get set }
 }
 


### PR DESCRIPTION
### Background
Apple announced that starting April 25, 2023, iOS, iPadOS, and watchOS apps submitted to the App Store must be built with Xcode 14.1 or later(https://developer.apple.com/news/?id=jd9wcyov ).
It should be verified that all iOS SampleApps in Sendbird run on Xcode14.1+.

### Summary
- [Set the ios version(11.0) of Podfile and Change class to AnyObject fo…](https://github.com/sendbird/quickstart-calls-groupcall-ios/commit/4f62a36054fbef906096b3f6d4eb5790cf1c1aa0)

### Further Comments
